### PR TITLE
fixes #40: account for mutation of map in getOrInsertComputed callbacks

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -43,6 +43,10 @@ contributors: Jonas Haukenes, Daniel Minor
     1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[MapData]], do
       1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
     1. Let _value_ be ? Call(_callbackfn_, *undefined*, « _key_ »).
+    1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[MapData]], do
+      1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
+        1. Set _p_.[[Value]] to _value_.
+        1. Return _value_.
     1. Let _p_ be the Record { [[Key]]: _key_, [[Value]]: _value_ }.
     1. Append _p_ to _M_.[[MapData]].
     1. Return _value_.
@@ -75,6 +79,10 @@ contributors: Jonas Haukenes, Daniel Minor
     1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[WeakMapData]], do
       1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
     1. Let _value_ be ? Call(_callbackfn_, *undefined*, « _key_ »).
+    1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[WeakMapData]], do
+      1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, then
+        1. Set _p_.[[Value]] to _value_.
+        1. Return _value_.
     1. Let _p_ be the Record { [[Key]]: _key_, [[Value]]: _value_ }.
     1. Append _p_ to _M_.[[WeakMapData]].
     1. Return _value_.


### PR DESCRIPTION
Fixes #40. Just checks for presence of the key again after calling the callback. @dead-claudia suggested we could have a note about a potential optimisation here, but I'll leave that to the editor group to decide upon integration.

Closes #73.