### PR TITLE
fixes #40: throw when map is mutated in getOrInsertComputed callbacks

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -43,6 +43,8 @@ contributors: Jonas Haukenes, Daniel Minor
     1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[MapData]], do
       1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
     1. Let _value_ be ? Call(_callbackfn_, *undefined*, « _key_ »).
+    1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[MapData]], do
+      1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, throw a *TypeError* exception.
     1. Let _p_ be the Record { [[Key]]: _key_, [[Value]]: _value_ }.
     1. Append _p_ to _M_.[[MapData]].
     1. Return _value_.
@@ -75,6 +77,8 @@ contributors: Jonas Haukenes, Daniel Minor
     1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[WeakMapData]], do
       1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, return _p_.[[Value]].
     1. Let _value_ be ? Call(_callbackfn_, *undefined*, « _key_ »).
+    1. For each Record { [[Key]], [[Value]] } _p_ of _M_.[[WeakMapData]], do
+      1. If _p_.[[Key]] is not ~empty~ and SameValue(_p_.[[Key]], _key_) is *true*, throw a *TypeError* exception.
     1. Let _p_ be the Record { [[Key]]: _key_, [[Value]]: _value_ }.
     1. Append _p_ to _M_.[[WeakMapData]].
     1. Return _value_.


### PR DESCRIPTION
Fixes #40. Alternative to #71 (closes #71).

Other currently unexplored options:
1. Throw only if the value is different.
1. Lock the map before calling the callback and throw in any mutating operation called from within the callback.
	1. The difference here being that we could catch and prohibit *any* mutation rather than just the addition of the key we're currently setting.