### PR TITLE
Add clarity to initial getOrInsert example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ an existing value.
 
 ```js
 // Currently
-let prefs = new getUserPrefs();
+let prefs = getUserPrefsMap();
 if (!prefs.has("useDarkmode")) {
   prefs.set("useDarkmode", true); // default to true
 }
 
 // Using getOrInsert
-let prefs = new getUserPrefs();
+let prefs = getUserPrefsMap();
 prefs.getOrInsert("useDarkmode", true); // default to true
 ```
 


### PR DESCRIPTION
The use of `new` seemed out of place in the initial example being used with what appeared to be a getter-style function and not a class (which are typically capitalized). Additionally the name was changed slightly to help enforce that the return value is expected to be a Map, the type on which the new methods would be available. 